### PR TITLE
Return `error` when `prefix` or `file_system_name` are truncated

### DIFF
--- a/examples/memfs/src/main.rs
+++ b/examples/memfs/src/main.rs
@@ -736,7 +736,9 @@ fn create_memory_file_system(mountpoint: &U16CStr) -> FileSystem<MemFs> {
         .set_persistent_acls(true)
         .set_post_cleanup_when_modified_only(true)
         .set_file_system_name(mountpoint)
-        .set_prefix(u16cstr!(""));
+        .unwrap()
+        .set_prefix(u16cstr!(""))
+        .unwrap();
 
     let params = Params {
         volume_params,

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -93,7 +93,9 @@ fn create_memory_file_system(mountpoint: &U16CStr) -> FileSystem<MemFs> {
 
     volume_params
         .set_file_system_name(mountpoint)
-        .set_prefix(u16cstr!(""));
+        .unwrap()
+        .set_prefix(u16cstr!(""))
+        .unwrap();
 
     let params = Params {
         volume_params,

--- a/winfsp_wrs/src/file_system.rs
+++ b/winfsp_wrs/src/file_system.rs
@@ -249,18 +249,34 @@ impl VolumeParams {
         self
     }
 
-    pub fn set_prefix(&mut self, val: &U16CStr) -> &mut Self {
-        let len = std::cmp::min(self.0.Prefix.len(), val.len());
+    /// # Error:
+    /// The value is too long (max length: 192), so it has been truncated.
+    pub fn set_prefix(&mut self, val: &U16CStr) -> Result<&mut Self, &mut Self> {
+        let max_len = self.0.Prefix.len();
 
-        self.0.Prefix[..len].copy_from_slice(&val.as_slice()[..len]);
-        self
+        if val.len() > max_len {
+            self.0.Prefix.copy_from_slice(&val.as_slice()[..max_len]);
+            Err(self)
+        } else {
+            self.0.Prefix[..val.len()].copy_from_slice(val.as_slice());
+            Ok(self)
+        }
     }
 
-    pub fn set_file_system_name(&mut self, val: &U16CStr) -> &mut Self {
-        let len = std::cmp::min(self.0.FileSystemName.len(), val.len());
+    /// # Error:
+    /// The value is too long (max length: 16), so it has been truncated.
+    pub fn set_file_system_name(&mut self, val: &U16CStr) -> Result<&mut Self, &mut Self> {
+        let max_len = self.0.FileSystemName.len();
 
-        self.0.FileSystemName[..len].copy_from_slice(&val.as_slice()[..len]);
-        self
+        if val.len() > max_len {
+            self.0
+                .FileSystemName
+                .copy_from_slice(&val.as_slice()[..max_len]);
+            Err(self)
+        } else {
+            self.0.FileSystemName[..val.len()].copy_from_slice(val.as_slice());
+            Ok(self)
+        }
     }
 
     pub fn set_volume_info_timeout(&mut self, val: u32) -> &mut Self {


### PR DESCRIPTION
closes #22 